### PR TITLE
Use max_popular_points in the simulator

### DIFF
--- a/simulator/simulator.py
+++ b/simulator/simulator.py
@@ -13,7 +13,7 @@ class Simulator:
     def simulate(self, number_of_requests):
         booking_distance_bins = self.get_booking_distance_bins(
             number_of_requests)
-        number_of_sample_points = max(
+        number_of_sample_points = min(
             number_of_requests, self.max_popular_points)
         most_popular_dropoff_points = self.get_random_points(
             number_of_sample_points)

--- a/simulator/simulator.py
+++ b/simulator/simulator.py
@@ -13,8 +13,12 @@ class Simulator:
     def simulate(self, number_of_requests):
         booking_distance_bins = self.get_booking_distance_bins(
             number_of_requests)
-        most_popular_dropoff_points = self.get_random_points(number_of_requests)
-        most_popular_pickup_points = self.get_random_points(number_of_requests)
+        number_of_sample_points = max(
+            number_of_requests, self.max_popular_points)
+        most_popular_dropoff_points = self.get_random_points(
+            number_of_sample_points)
+        most_popular_pickup_points = self.get_random_points(
+            number_of_sample_points)
 
         return {
             'booking_distance_bins': booking_distance_bins,


### PR DESCRIPTION
## Description
It was intended to sample max 10 points for the most popular pickup and dropoff points, but the variable was never used (this was pointed out in a challenge submission, actually).

Now, we return max `10` pickup/dropoff points as "most popular".